### PR TITLE
After recent Windows upgrade jstz library is failing on Windows serve…

### DIFF
--- a/jstz.main.js
+++ b/jstz.main.js
@@ -101,7 +101,7 @@ var jstz = (function () {
          */
         get_from_internationalization_api = function get_from_internationalization_api() {
             var format, timezone;
-            if (typeof Intl === "undefined" || typeof Intl.DateTimeFormat === "undefined") {
+            if (!Intl || typeof Intl === "undefined" || typeof Intl.DateTimeFormat === "undefined") {
                 return;
             }
 


### PR DESCRIPTION
After recent Windows upgrade jstz library is failing on Windows server 2012 R2 and Windows 8.1

https://support.microsoft.com/en-us/help/4489881/windows-8-1-update-kb4489881

Other libraries using Intl also are facing this issue and have wrapped their code in try catch to avoid this.